### PR TITLE
Use SPDX license identifier

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ authors:
   - Mark Goddard <mark@stackhpc.com>
 description: Ansible collection for configuring linux based operating systems
 license:
-  - Apache2
+  - "Apache-2.0"
 tags:
   - linux
 dependencies: {}


### PR DESCRIPTION
Hit the following errors when publishing the role:

```
Error:  [ERROR]: Galaxy import error message: Import Task "29818" failed: Invalid
Publishing collection artifact '/home/runner/work/ansible-collection-linux/ansible-collection-linux/stackhpc-linux-1.0.0.tar.gz' to default https://galaxy.ansible.com/api/
Collection has been published to the Galaxy server default https://galaxy.ansible.com/api/
Waiting until Galaxy import task https://galaxy.ansible.com/api/v2/collection-imports/29818/ has completed
collection metadata. Expecting 'license' to be a list of valid SPDX license
identifiers, instead found invalid license identifiers: 'Apache2' in 'license'
value ['Apache2']. For more info, visit https://spdx.org
ERROR! Galaxy import process failed: Invalid collection metadata. Expecting 'license' to be a list of valid SPDX license identifiers, instead found invalid license identifiers: 'Apache2' in 'license' value ['Apache2']. For more info, visit https://spdx.org (Code: None)
```

See:
- https://github.com/stackhpc/ansible-collection-linux/actions/runs/5609573688/job/15197473526 
-  https://spdx.org/licenses/