### PR TITLE
Create runtime.yml

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.9"


### PR DESCRIPTION
```
Error:  [ERROR]: Galaxy import error message: Import Task "29939" failed:
Publishing collection artifact '/home/runner/work/ansible-collection-linux/ansible-collection-linux/stackhpc-linux-1.0.0.tar.gz' to default https://galaxy.ansible.com/api/
'requires_ansible' in meta/runtime.yml is mandatory, but no meta/runtime.yml
Collection has been published to the Galaxy server default https://galaxy.ansible.com/api/
found
Waiting until Galaxy import task https://galaxy.ansible.com/api/v2/collection-imports/29939/ has completed
ERROR! Galaxy import process failed: 'requires_ansible' in meta/runtime.yml is mandatory, but no meta/runtime.yml found (Code: None)
```

See:  https://github.com/stackhpc/ansible-collection-linux/actions/runs/5645877621/