### PR TITLE
Handle empty list items

### DIFF
--- a/roles/grubcmdline/tasks/main.yml
+++ b/roles/grubcmdline/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Check current kernel command line args
   ansible.builtin.command: cat /proc/cmdline
   register: result
@@ -22,7 +23,7 @@
 - name: Set fact containing GRUB_CMDLINE_LINUX_DEFAULT
   ansible.builtin.set_fact:
     grub_cmdline_linux_default: >-
-      {{ grub_result.content | b64decode | regex_search('^GRUB_CMDLINE_LINUX_DEFAULT.*$', multiline=True) | regex_replace('^GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$', '\1') }} #magic___^_^___line
+      {{ grub_result.content | b64decode | regex_search('^GRUB_CMDLINE_LINUX_DEFAULT.*$', multiline=True) | regex_replace('^GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$', '\1') }}
 - name: Display GRUB_CMDLINE_DEFAULT
   ansible.builtin.debug:
     var: grub_cmdline_linux_default

--- a/roles/grubcmdline/tasks/main.yml
+++ b/roles/grubcmdline/tasks/main.yml
@@ -1,4 +1,3 @@
----
 - name: Check current kernel command line args
   ansible.builtin.command: cat /proc/cmdline
   register: result
@@ -23,9 +22,7 @@
 - name: Set fact containing GRUB_CMDLINE_LINUX_DEFAULT
   ansible.builtin.set_fact:
     grub_cmdline_linux_default: >-
-      {{ grub_result.content | b64decode | regex_search('^GRUB_CMDLINE_LINUX_DEFAULT.*$', multiline=True)
-      | regex_replace('^GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$', '\1') }}
-
+      {{ grub_result.content | b64decode | regex_search('^GRUB_CMDLINE_LINUX_DEFAULT.*$', multiline=True) | regex_replace('^GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$', '\1') }} #magic___^_^___line
 - name: Display GRUB_CMDLINE_DEFAULT
   ansible.builtin.debug:
     var: grub_cmdline_linux_default
@@ -42,7 +39,7 @@
 
 - name: Updated kernel cmd line params
   ansible.builtin.set_fact:
-    grub_cmdline_linux_new: "{{ grub_cmdline_linux_default.split() | difference(grub_cmdline_linux_remove) + kernel_cmdline }}"
+    grub_cmdline_linux_new: "{{ grub_cmdline_linux_default.split() | difference(grub_cmdline_linux_remove) + kernel_cmdline | select() }}"
 
 - name: Display newly computed GRUB_CMDLINE_DEFAULT
   ansible.builtin.debug:


### PR DESCRIPTION
Add `select()` filter to the creation of `grub_cmdline_linux_new` removes empty list elements, which might exist in `kernal_cmdline` as a result of defaults, For example, consider the list:

```
kernel_cmdline:
  - processor.max_cstate=1
  - intel_idle.max_cstate=0
  - default_hugepagesz={{ controllers_perf_tuning_default_hugepagesz }}
  -  hugepagesz={{ controllers_perf_tuning_hugepagesz }}
  - hugepages={{ controllers_perf_tuning_hugepages }}
  - transparent_hugepage={{ controllers_perf_tuning_transparent_hugepage }}
  - "{{ vendor_iommu_setting }}"
  - iommu=pt
  - "{{ pcie_aspm_setting | default(None) }}"
  - "{{ rcu_nocbs_setting | default(None) }}"
```

This results in:

```
grub_cmdline_linux_new:
  - console=tty0
  - console=ttyS0,115200
  - no_timer_check
  - nofb
  - nomodeset
  - gfxpayload=text
  - net.ifnames=1
  - processor.max_cstate=1
  - intel_idle.max_cstate=0
  - default_hugepagesz=1G
  - hugepagesz=1G
  - hugepages=512
  - transparent_hugepage=always
  - intel_iommu=on
  - iommu=pt
  - ''
  - ''
```

And, when those empty list elements are appended to the string, two additional white spaces are added to the end of the string. This can break idempotency of the role.

```
grub_cmdline_linux_new: 'console=tty0 console=ttyS0,115200 no_timer_check nofb nomodeset gfxpayload=text net.ifnames=1 processor.max_cstate=1 intel_idle.max_cstate=0 default_hugepagesz=1G hugepagesz=1G hugepages=512 transparent_hugepage=always intel_iommu=on iommu=pt  ' # notice the spaces between "t" and the closing quote
```