### PR TITLE
Handle missing GRUB_CMDLINE_LINUX_DEFAULT variable

### DIFF
--- a/roles/grubcmdline/tasks/main.yml
+++ b/roles/grubcmdline/tasks/main.yml
@@ -25,9 +25,22 @@
     grub_cmdline_linux_default: >-
       {{ grub_result.content | b64decode | regex_search('^GRUB_CMDLINE_LINUX_DEFAULT.*$', multiline=True) | regex_replace('^GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$', '\1') }}
 
+- name: Set fact containing GRUB_CMDLINE_LINUX
+  ansible.builtin.set_fact:
+    grub_cmdline_linux: >-
+      {{ grub_result.content | b64decode | regex_search('^GRUB_CMDLINE_LINUX=.*$', multiline=True) | regex_replace('^GRUB_CMDLINE_LINUX="(.*)"$', '\1') }}
+
 - name: Display GRUB_CMDLINE_LINUX_DEFAULT
   ansible.builtin.debug:
     var: grub_cmdline_linux_default
+
+- name: Display GRUB_CMDLINE_LINUX
+  ansible.builtin.debug:
+    var: grub_cmdline_linux
+
+- ansible.builtin.set_fact:
+    grub_cmdline_linux_default: "{{ grub_cmdline_linux }}"
+  when: grub_cmdline_linux_default == 'None'
 
 - name: Determine which parameters need removing
   # We use a regex here so you can remove parameters regardless of their value, e.g to remove iommu=on you

--- a/roles/grubcmdline/tasks/main.yml
+++ b/roles/grubcmdline/tasks/main.yml
@@ -24,7 +24,8 @@
   ansible.builtin.set_fact:
     grub_cmdline_linux_default: >-
       {{ grub_result.content | b64decode | regex_search('^GRUB_CMDLINE_LINUX_DEFAULT.*$', multiline=True) | regex_replace('^GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$', '\1') }}
-- name: Display GRUB_CMDLINE_DEFAULT
+
+- name: Display GRUB_CMDLINE_LINUX_DEFAULT
   ansible.builtin.debug:
     var: grub_cmdline_linux_default
 
@@ -42,7 +43,7 @@
   ansible.builtin.set_fact:
     grub_cmdline_linux_new: "{{ grub_cmdline_linux_default.split() | difference(grub_cmdline_linux_remove) + kernel_cmdline | select() }}"
 
-- name: Display newly computed GRUB_CMDLINE_DEFAULT
+- name: Display newly computed GRUB_CMDLINE_LINUX_DEFAULT
   ansible.builtin.debug:
     var: grub_cmdline_linux_new
 


### PR DESCRIPTION
If `GRUB_CMDLINE_LINUX_DEFAULT` is unset in `/etc/default/grub`, initialise it from `GRUB_CMDLINE_LINUX`. We write back the updated kernel command line as `GRUB_CMDLINE_LINUX_DEFAULT`, so it will only apply to normal (non-rescue) boots.

Fixes https://github.com/stackhpc/ansible-collection-linux/issues/18.