### PR TITLE
Bugfix - grubcmdline reboot detection triggered by empty values in list

### DIFF
--- a/roles/grubcmdline/tasks/main.yml
+++ b/roles/grubcmdline/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: Notify reboot handler
   ansible.builtin.debug:
     msg: Old command line was {{ result.stdout }}
-  changed_when: old_cmdline != kernel_cmdline | sort | list
+  changed_when: old_cmdline != kernel_cmdline | select() | sort | list
   notify: "{{ kernel_restart_handler }}"
 
 - name: Slurp /etc/default/grub

--- a/roles/grubcmdline/vars/main.yml
+++ b/roles/grubcmdline/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # Should match on all of the the cmd line parameters
-kernel_cmdline_regex: "{{ '(' ~ kernel_cmdline | map('regex_escape') | list | join('|') ~ ')' }}" # noqa var-naming[no-role-prefix]
+kernel_cmdline_regex: "{{ '(' ~ kernel_cmdline | select() | map('regex_escape') | list | join('|') ~ ')' }}" # noqa var-naming[no-role-prefix]
 
 kernel_cmdline_sorted: "{{ kernel_cmdline | sort }}" # noqa var-naming[no-role-prefix]
 


### PR DESCRIPTION
This relates to https://github.com/stackhpc/ansible-collection-linux/pull/17.   @jjo93sa 's fix correctly manages empty values for the grub.cfg, but a reboot signal is still sent by:

`  changed_when: old_cmdline != kernel_cmdline | sort | list `

There are two things that break the comparison:

Firstly:
 ` kernel_cmdline | sort | list ` contains the empty values


and then, the empty values break the kernel_cmdline_regex filter here:

`     old_cmdline: "{{ result.stdout.split() | select('search', kernel_cmdline_regex) | sort | list }}" `

and old_cmdline is then populated with the full /proc/cmdline:

```
TASK [stackhpc.grubcmdline : debug old_cmdline] ********************************************************************************
Tuesday 20 February 2024  10:36:17 +0000 (0:00:00.095)       0:00:04.813 ******
ok: [gbnwp-pipusm002] =>
  msg: 'old_cmdline: [''amd_iommu=on'', ''BOOT_IMAGE=(lvmid/BYn8R2-JzSS-JlkG-1cdt-x3rv-NJSM-5gtfuL/Vy29GZ-3MKn-0ipZ-yAG9-t0ya-DOGq-TAj4iB)/boot/vmlinuz-5.14.0-284.30.1.el9_2.x86_64'', ''console=tty0'', ''console=ttyS0,115200'', ''default_hugepagesz=1G'', ''gfxpayload=text'', ''hugepages=0'', ''hugepagesz=1G'', ''i40e.blacklist=1'', ''intel_idle.max_cstate=0'', ''iommu=pt'', ''net.ifnames=1'', ''no_timer_check'', ''nofb'', ''nomodeset'', ''processor.max_cstate=1'', ''rd.driver.blacklist=i40e'', ''ro'', ''root=LABEL=rootfs'', ''transparent_hugepage=always''] '
```

rather than the expected
```
TASK [stackhpc.grubcmdline : debug old_cmdline] ************************************************************************************************************
Tuesday 20 February 2024  10:44:01 +0000 (0:00:00.094)       0:00:06.160 ******
ok: [gbnwp-pipusm002] =>
  msg: 'old_cmdline: [''amd_iommu=on'', ''default_hugepagesz=1G'', ''hugepages=0'', ''hugepagesz=1G'', ''intel_idle.max_cstate=0'', ''iommu=pt'', ''processor.max_cstate=1'', ''transparent_hugepage=always''] '
```