### PR TITLE
Iommu update for Rocky Linux 9

### DIFF
--- a/roles/iommu/README.md
+++ b/roles/iommu/README.md
@@ -20,3 +20,19 @@
       become: true
 
 ```
+
+Or if you want the node to reboot automatically
+
+```
+---
+- name: Enable IOMMU
+  hosts: iommu
+  tasks:
+    - import_role:
+      name: stackhpc.linux.iommu
+  handlers:
+    - name: reboot
+      reboot:
+      become: true
+
+```

--- a/roles/iommu/handlers/main.yml
+++ b/roles/iommu/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Regenerate initramfs
+  ansible.builtin.shell: |-
+    #!/bin/bash
+    set -eux
+    dracut -v -f /boot/initramfs-$(uname -r).img $(uname -r)
+  become: true
+  changed_when: true

--- a/roles/iommu/tasks/main.yml
+++ b/roles/iommu/tasks/main.yml
@@ -1,12 +1,43 @@
 ---
+- name: Template dracut config for vfio
+  ansible.builtin.blockinfile:
+    path: /etc/dracut.conf.d/gpu-vfio.conf
+    block: |
+      add_drivers+="vfio vfio_iommu_type1 vfio_pci vfio_virqfd"
+    owner: root
+    group: root
+    mode: "0660"
+    create: true
+  become: true
+  when: iommu_vfio_pci_ids is defined
+  notify:
+    - Regenerate initramfs
+    - reboot
+
+- name: Add vfio to modules-load.d
+  ansible.builtin.blockinfile:
+    path: /etc/modules-load.d/vfio.conf
+    block: |
+      vfio
+      vfio_iommu_type1
+      vfio_pci
+      vfio_virqfd
+    owner: root
+    group: root
+    mode: "0664"
+    create: true
+  become: true
+  when: iommu_vfio_pci_ids is defined
+  notify: reboot
+
 - name: Add iommu to kernel command line (Intel)
   ansible.builtin.include_role:
     name: stackhpc.linux.grubcmdline
   vars:
-    kernel_cmdline: # noqa: var-naming[no-role-prefix]
-      - intel_iommu=on
+    kernel_cmdline: "{{ ['intel_iommu=on'] + (['vfio-pci.ids=' + iommu_vfio_pci_ids] if iommu_vfio_pci_ids is defined else []) }}"  # noqa: var-naming[no-role-prefix]
     kernel_cmdline_remove: # noqa: var-naming[no-role-prefix]
       - ^intel_iommu=
+      - ^vfio-pci\.ids=
   when: ansible_facts.processor | select('search', 'Intel') | list | length > 0
 
 - name: Set iommu=pt


### PR DESCRIPTION
When enabling iommu on RL9 hypervisors the check `when: "'Intel' in ansible_facts.processor.0"` kept failing as it returned 0. Not sure how the check was working before but now `ansible_facts.processor.1` contains the line that has `Intel` in it as ansible combines the lists into one list. We now use a seach for Intel in the list to pass the check: `when: ansible_facts.processor | select('search', 'Intel') | list | length > 0`

Additionally, added support for specifying vfio-pci Id's in the cmdline.