### PR TITLE
fix references to old roles

### DIFF
--- a/roles/grubcmdline/README.md
+++ b/roles/grubcmdline/README.md
@@ -1,4 +1,4 @@
-stackhpc.grubcmdline
+stackhpc.linux.grubcmdline
 ====================
 
 Sets the default kernel command line
@@ -34,7 +34,7 @@ Example Playbook
       - hugepage
   tasks:
     - include_role:
-        name: stackhpc.grubcmdline
+        name: stackhpc.linux.grubcmdline
   handlers:
     - name: reboot
       include_tasks: tasks/reboot.yml

--- a/roles/grubcmdline/handlers/main.yml
+++ b/roles/grubcmdline/handlers/main.yml
@@ -1,2 +1,2 @@
 ---
-# handlers file for stackhpc.grubcmdline
+# handlers file for stackhpc.linux.grubcmdline

--- a/roles/sriov/README.md
+++ b/roles/sriov/README.md
@@ -1,4 +1,4 @@
-stackhpc.sriov
+stackhpc.linux.sriov
 ==============
 
 [![Build Status](https://travis-ci.com/stackhpc/ansible-role-sriov.svg?branch=master)](https://travis-ci.com/stackhpc/ansible-role-sriov)
@@ -17,7 +17,7 @@ See `defaults/main.yml`
 Dependencies
 ------------
 
-- `stackhpc.grubcmdline`
+- `stackhpc.linux.grubcmdline`
 
 Example Playbook
 ----------------

--- a/roles/sriov/tasks/config.yml
+++ b/roles/sriov/tasks/config.yml
@@ -18,7 +18,7 @@
 
 - name: Add iommu to kernel command line (Intel)
   ansible.builtin.include_role:
-    name: stackhpc.grubcmdline
+    name: stackhpc.linux.grubcmdline
   tags: skip_when_testing
   vars:
     kernel_cmdline: # noqa var-naming[no-role-prefix]
@@ -30,7 +30,7 @@
 
 - name: Set iommu=pt
   ansible.builtin.include_role:
-    name: stackhpc.grubcmdline
+    name: stackhpc.linux.grubcmdline
   tags: skip_when_testing
   vars:
     kernel_cmdline: # noqa var-naming[no-role-prefix]

--- a/roles/sriov/vars/main.yml
+++ b/roles/sriov/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-# vars file for stackhpc.sriov
+# vars file for stackhpc.linux.sriov


### PR DESCRIPTION
stackhpc.linux.grubcmdline: only readme and comment
stackhpc.linux.sriov: references to stackhpc.grubcmdline