### PR TITLE
Allow to get kernel cmdline in check mode

### DIFF
--- a/roles/grubcmdline/tasks/main.yml
+++ b/roles/grubcmdline/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.command: cat /proc/cmdline
   register: result
   changed_when: false
+  check_mode: false
 
 - name: Determine if we need to update
   ansible.builtin.set_fact:


### PR DESCRIPTION
Without this change, Ansible running in check mode won't be able to detect whether a reboot is needed.