### PR TITLE
Update GRUB command line only if parameters change

### DIFF
--- a/roles/grubcmdline/tasks/main.yml
+++ b/roles/grubcmdline/tasks/main.yml
@@ -53,6 +53,7 @@
     line: GRUB_CMDLINE_LINUX_DEFAULT="{{ grub_cmdline_linux_new | join(' ') }}"
     backup: "{{ backup_grub_config_file }}"
   become: true
+  when: grub_cmdline_linux_default.split() | sort | list != grub_cmdline_linux_new | sort | list
 
 - name: Generate new grub-config (RedHat <= 8.x)
   ansible.builtin.command: grub2-mkconfig


### PR DESCRIPTION
The grubcmdline role can be invoked like in the following example:

    - name: Set iommu=pt
      include_role:
        name: stackhpc.linux.grubcmdline
      vars:
        kernel_cmdline:
          - iommu=pt kernel_cmdline_remove:
          - ^iommu=

When the role is called multiple times with parameters kernel_cmdline and kernel_cmdline_remove, each execution moves its kernel parameters at the end of the command line. This means each full execution would always update GRUB, even when the end result would be the same.

Fix by comparing the existing command line with the newly generated one as sets and only updating GRUB_CMDLINE_LINUX_DEFAULT if they are different.