### PR TITLE
Grubcmdline: Support Ubuntu/ cloud-init combination

### DIFF
--- a/roles/grubcmdline/defaults/main.yml
+++ b/roles/grubcmdline/defaults/main.yml
@@ -9,3 +9,6 @@ kernel_restart_handler: reboot # noqa var-naming[no-role-prefix]
 # optionally skip backing up the config file. Can cause issues on some
 # filesystems due to filenames containing illegal characters
 backup_grub_config_file: true # noqa var-naming[no-role-prefix]
+
+default_grub_conf: "/etc/default/grub"
+cloudinit_grub_conf: "/etc/default/grub.d/50-cloudimg-settings.cfg"

--- a/roles/grubcmdline/tasks/main.yml
+++ b/roles/grubcmdline/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Set fact with the grub conf file path
   ansible.builtin.set_fact:
-    grub_conf_file: cloudinit_result.stat.exists | ternary(cloudinit_grub_conf, default_grub_conf)
+    grub_conf_file: "{{ cloudinit_result.stat.exists | ternary(cloudinit_grub_conf, default_grub_conf) }}"
 
 - name: Slurp grub config file
   ansible.builtin.slurp:

--- a/roles/grubcmdline/tasks/main.yml
+++ b/roles/grubcmdline/tasks/main.yml
@@ -15,9 +15,18 @@
   changed_when: old_cmdline != kernel_cmdline | select() | sort | list
   notify: "{{ kernel_restart_handler }}"
 
-- name: Slurp /etc/default/grub
+- name: Look for cloud-init grub file
+  ansible.builtin.stat:
+    path: "{{ cloudinit_grub_conf }}"
+  register: cloudinit_result
+
+- name: Set fact with the grub conf file path
+  ansible.builtin.set_fact:
+    grub_conf_file: cloudinit_result.stat.exists | ternary(cloudinit_grub_conf, default_grub_conf)
+
+- name: Slurp grub config file
   ansible.builtin.slurp:
-    path: /etc/default/grub
+    path: "{{ grub_conf_file }}"
   register: grub_result
   become: true
 
@@ -47,9 +56,9 @@
   ansible.builtin.debug:
     var: grub_cmdline_linux_new
 
-- name: Set GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub
+- name: Set GRUB_CMDLINE_LINUX_DEFAULT in the appropriate grub conf
   ansible.builtin.lineinfile:
-    path: /etc/default/grub
+    path: "{{ grub_conf_file }}"
     regexp: ^GRUB_CMDLINE_LINUX_DEFAULT
     line: GRUB_CMDLINE_LINUX_DEFAULT="{{ grub_cmdline_linux_new | join(' ') }}"
     backup: "{{ backup_grub_config_file }}"


### PR DESCRIPTION
In our testing it seems that Ubuntu-based cloud-init images use alternate grub config file.

Ubuntu images with cloudinit use a different base/source for its grub configuration than Redhat derivatives - `/etc/default/grub.d/50-cloudimg-settings.cfg` not `/etc/default/grub`.

 We look for the cloud-init config file and use that in the future commands, otherwise default to /etc/default/grub file.