### PR TITLE
Fix permanently enabling systemd-networkd

### DIFF
--- a/roles/systemd_networkd/tasks/main.yml
+++ b/roles/systemd_networkd/tasks/main.yml
@@ -17,10 +17,19 @@
 
 - name: Enable systemd-networkd
   become: true
-  ansible.builtin.service:
-    name: systemd-networkd
-    enabled: true
   when: systemd_networkd_network or systemd_networkd_link or systemd_networkd_netdev
+  block:
+    # TODO(mattcrees): Remove once this gets into a versioned release:
+    # https://github.com/ansible/ansible/pull/77754
+    - name: Temporarily disable systemd-networkd
+      ansible.builtin.service:
+        name: systemd-networkd
+        enabled: false
+
+    - name: Enable systemd-networkd
+      ansible.builtin.service:
+        name: systemd-networkd
+        enabled: true
 
 - name: Start and enable systemd-resolved
   become: true


### PR DESCRIPTION
Work around the service module not yet handling "enabled-runtime" properly. This patch should be reverted when the following can be used: https://github.com/ansible/ansible/pull/77754