### PR TITLE
vgpu: Improve reliability of enabling sriov

### DIFF
--- a/roles/vgpu/templates/nvidia-mdev.service.j2
+++ b/roles/vgpu/templates/nvidia-mdev.service.j2
@@ -12,7 +12,9 @@ RestartSec=30
 Type=oneshot
 User=root
 {% if vgpu_definition.mig_devices is not defined %}
-# Workaround lack of UpheldBy/RestartMode=direct in systemd<254
+# Workaround lack of UpheldBy/RestartMode=direct in systemd<254 to ensure unit is
+# started when the dependency fails, see:
+# https://unix.stackexchange.com/questions/213185/restarting-systemd-service-on-dependency-failure
 ExecStartPre=/usr/bin/systemctl is-active nvidia-sriov-{{ vgpu_definition.pci_address }}.service
 {% endif %}
 ExecStart=-/usr/sbin/mdevctl start --uuid %i

--- a/roles/vgpu/templates/nvidia-mdev.service.j2
+++ b/roles/vgpu/templates/nvidia-mdev.service.j2
@@ -4,9 +4,6 @@ Before=docker.service
 {% if vgpu_definition.mig_devices is defined %}
 After=nvidia-mig-manager.service
 Requires=nvidia-mig-manager.service
-{% else %}
-After=nvidia-sriov-{{ vgpu_definition.pci_address }}.service
-Requires=nvidia-sriov-{{ vgpu_definition.pci_address }}.service
 {% endif %}
 
 [Service]
@@ -14,7 +11,10 @@ Restart=on-failure
 RestartSec=30
 Type=oneshot
 User=root
-ExecStartPre=/bin/sleep 5
+{% if vgpu_definition.mig_devices is not defined %}
+# Workaround lack of UpheldBy/RestartMode=direct in systemd<254
+ExecStartPre=/usr/bin/systemctl is-active nvidia-sriov-{{ vgpu_definition.pci_address }}.service
+{% endif %}
 ExecStart=-/usr/sbin/mdevctl start --uuid %i
 RemainAfterExit=yes
 

--- a/roles/vgpu/templates/nvidia-mdev.service.j2
+++ b/roles/vgpu/templates/nvidia-mdev.service.j2
@@ -10,6 +10,8 @@ Requires=nvidia-sriov-{{ vgpu_definition.pci_address }}.service
 {% endif %}
 
 [Service]
+Restart=on-failure
+RestartSec=30
 Type=oneshot
 User=root
 ExecStartPre=/bin/sleep 5

--- a/roles/vgpu/templates/nvidia-sriov.service.j2
+++ b/roles/vgpu/templates/nvidia-sriov.service.j2
@@ -10,13 +10,14 @@ Restart=on-failure
 RestartSec=30
 Type=oneshot
 User=root
-# NOTE(wszumski): There is a race in the driver initialization where if we run this too early, then
-# the mdev_support_devices entry doesn't show up in sysfs. I was unable to get this to show up again
-# without a reboot.
+# NOTE(wszumski): There is a race in the driver initialization where if we run
+# this too early, then the mdev_support_devices entry doesn't show up in sysfs.
+# I was unable to get this to show up again without a reboot.
 ExecStartPre=/bin/sleep 5
-# NOTE(wszumski): The sriov-manage script will unbind the nvidia driver to initialize the virtual functions.
-# If it fails part way through, the driver can be left unbound and subsequent executions of sriov-mange
-# will fail. This ensures that the nvidia driver is always bound before we run sriov-manage.
+# NOTE(wszumski): The sriov-manage script will unbind the nvidia driver to
+# initialize the virtual functions.  If it fails part way through, the driver
+# can be left unbound, and subsequent executions of sriov-mange will fail. This
+# ensures that the nvidia driver is always bound before we run sriov-manage.
 ExecStart=/bin/bash -c "echo '{{ vgpu_definition.pci_address }}' > /sys/bus/pci/drivers/nvidia/bind || true"
 ExecStart=/usr/lib/nvidia/sriov-manage -e {{ vgpu_definition.pci_address }}
 RemainAfterExit=yes

--- a/roles/vgpu/templates/nvidia-sriov.service.j2
+++ b/roles/vgpu/templates/nvidia-sriov.service.j2
@@ -6,12 +6,15 @@ After=local-fs.target {{ vgpu_systemd_device[vgpu_definition.pci_address] }}
 Wants={{ vgpu_systemd_device[vgpu_definition.pci_address] }}
 
 [Service]
+Restart=on-failure
+RestartSec=30
 Type=oneshot
 User=root
 # NOTE(wszumski): There is a race in the driver initialization where if we run this too early, then
 # the mdev_support_devices entry doesn't show up in sysfs. I was unable to get this to show up again
 # without a reboot.
 ExecStartPre=/bin/sleep 5
+ExecStart=/bin/bash -c "echo '{{ vgpu_definition.pci_address }}' > /sys/bus/pci/drivers/nvidia/bind || true"
 ExecStart=/usr/lib/nvidia/sriov-manage -e {{ vgpu_definition.pci_address }}
 RemainAfterExit=yes
 

--- a/roles/vgpu/templates/nvidia-sriov.service.j2
+++ b/roles/vgpu/templates/nvidia-sriov.service.j2
@@ -14,6 +14,9 @@ User=root
 # the mdev_support_devices entry doesn't show up in sysfs. I was unable to get this to show up again
 # without a reboot.
 ExecStartPre=/bin/sleep 5
+# NOTE(wszumski): The sriov-manage script will unbind the nvidia driver to initialize the virtual functions.
+# If it fails part way through, the driver can be left unbound and subsequent executions of sriov-mange
+# will fail. This ensures that the nvidia driver is always bound before we run sriov-manage.
 ExecStart=/bin/bash -c "echo '{{ vgpu_definition.pci_address }}' > /sys/bus/pci/drivers/nvidia/bind || true"
 ExecStart=/usr/lib/nvidia/sriov-manage -e {{ vgpu_definition.pci_address }}
 RemainAfterExit=yes


### PR DESCRIPTION
There is a race condition on boot:

```
[stack@gpu2 ~]$ sudo journalctl -u nvidia-sriov-0000:17:00.0.service
Jan 09 12:13:11 gpu2 systemd[1]: Starting Enable SR-IOV on Nvidia card (0000:17:00.0)...
Jan 09 12:13:16 gpu2 sriov-manage[3802]: Enabling VFs on 0000:17:00.0
Jan 09 12:13:17 gpu2 sriov-manage[3837]: awk: (FILENAME=- FNR=1) warning: error writing standard output: File exists
Jan 09 12:13:17 gpu2 sriov-manage[3899]: awk: (FILENAME=- FNR=1) warning: error writing standard output: No such device
Jan 09 12:13:17 gpu2 systemd[1]: nvidia-sriov-0000:17:00.0.service: Main process exited, code=exited, status=1/FAILURE
Jan 09 12:13:17 gpu2 systemd[1]: nvidia-sriov-0000:17:00.0.service: Failed with result 'exit-code'.
Jan 09 12:13:17 gpu2 systemd[1]: Failed to start Enable SR-IOV on Nvidia card (0000:17:00.0).
```

This has been observed on Rocky 9.4 with NVIDIA-AI-Enterprise-Linux-KVM-550.127.06-550.127.05-553.24.

We can work around this by retrying. The sriov-manage script can leave the driver unbound, so we first ensure that the NVIDIA driver is bound to the card.