### PR TITLE
Increase delay before trying to enable sriov

### DIFF
--- a/roles/vgpu/defaults/main.yml
+++ b/roles/vgpu/defaults/main.yml
@@ -5,7 +5,7 @@ vgpu_driver_dkms: false
 vgpu_do_reboot: true
 vgpu_reboot_timeout: 3600
 
-# Time in seconds to sleep before enabling sriov on 
+# Time in seconds to sleep before enabling sriov
 vgpu_sriov_init_delay: 30
 
 # Deprecated: use vgpu_definitions instead.

--- a/roles/vgpu/defaults/main.yml
+++ b/roles/vgpu/defaults/main.yml
@@ -5,6 +5,9 @@ vgpu_driver_dkms: false
 vgpu_do_reboot: true
 vgpu_reboot_timeout: 3600
 
+# Time in seconds to sleep before enabling sriov on 
+vgpu_sriov_init_delay: 30
+
 # Deprecated: use vgpu_definitions instead.
 vgpu_mig_definitions: []
 vgpu_definitions: "{{ vgpu_mig_definitions }}"

--- a/roles/vgpu/templates/nvidia-sriov.service.j2
+++ b/roles/vgpu/templates/nvidia-sriov.service.j2
@@ -13,7 +13,7 @@ User=root
 # NOTE(wszumski): There is a race in the driver initialization where if we run
 # this too early, then the mdev_support_devices entry doesn't show up in sysfs.
 # I was unable to get this to show up again without a reboot.
-ExecStartPre=/bin/sleep 5
+ExecStartPre=/bin/sleep 30
 # NOTE(wszumski): The sriov-manage script will unbind the nvidia driver to
 # initialize the virtual functions.  If it fails part way through, the driver
 # can be left unbound, and subsequent executions of sriov-mange will fail. This

--- a/roles/vgpu/templates/nvidia-sriov.service.j2
+++ b/roles/vgpu/templates/nvidia-sriov.service.j2
@@ -13,7 +13,7 @@ User=root
 # NOTE(wszumski): There is a race in the driver initialization where if we run
 # this too early, then the mdev_support_devices entry doesn't show up in sysfs.
 # I was unable to get this to show up again without a reboot.
-ExecStartPre=/bin/sleep 30
+ExecStartPre=/bin/sleep {{ vgpu_sriov_init_delay }}
 # NOTE(wszumski): The sriov-manage script will unbind the nvidia driver to
 # initialize the virtual functions.  If it fails part way through, the driver
 # can be left unbound, and subsequent executions of sriov-mange will fail. This


### PR DESCRIPTION
Starting this too early gets the cards into a bad state. You get the following error when trying to start an mdev device:

```
stderr: 'Error: Parent 0000:81:00.4 is not currently registered for mdev support'
```