### PR TITLE
Adds vgpu_mig_enabled as a role default

### DIFF
--- a/roles/vgpu/defaults/main.yml
+++ b/roles/vgpu/defaults/main.yml
@@ -15,6 +15,9 @@ vgpu_sriov_init_delay: 30
 vgpu_mig_definitions: []
 vgpu_definitions: "{{ vgpu_mig_definitions }}"
 
+# Whether to enable MIG support. This is required when using MIG.
+vgpu_mig_enabled: "{{ vgpu_definitions | selectattr('mig_devices', 'defined') | length > 0 }}"
+
 # Packages providing nvidia-mig-manager
 vgpu_nvidia_mig_manager_rpm_url: https://github.com/NVIDIA/mig-parted/releases/download/v0.12.1/nvidia-mig-manager-0.12.1-1.x86_64.rpm
 vgpu_nvidia_mig_manager_deb_url: https://github.com/NVIDIA/mig-parted/releases/download/v0.12.1/nvidia-mig-manager_0.12.1-1_amd64.deb

--- a/roles/vgpu/tasks/install.yml
+++ b/roles/vgpu/tasks/install.yml
@@ -80,7 +80,7 @@
   become: true
   when:
     - ansible_facts.os_family == "RedHat"
-    - vgpu_mig_enabled
+    - vgpu_mig_enabled | bool
 
 - name: Install nvidia-mig-manager (Debian)
   ansible.builtin.package:
@@ -89,4 +89,4 @@
   become: true
   when:
     - ansible_facts.os_family == "Debian"
-    - vgpu_mig_enabled
+    - vgpu_mig_enabled | bool

--- a/roles/vgpu/vars/main.yml
+++ b/roles/vgpu/vars/main.yml
@@ -1,2 +1,0 @@
----
-vgpu_mig_enabled: "{{ vgpu_definitions | selectattr('mig_devices', 'defined') | length > 0 }}"


### PR DESCRIPTION
This allows users to override this variable more easily if they want to force MIG support e.g in an image build where the vgpu definitions are not defined yet.