### PR TITLE
Support requiring explicit permission to reboot

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: stackhpc
 name: linux
-version: 1.5.2
+version: 1.6.0
 readme: README.md
 authors:
   - Mark Goddard <mark@stackhpc.com>

--- a/roles/grubcmdline/defaults/main.yml
+++ b/roles/grubcmdline/defaults/main.yml
@@ -9,3 +9,5 @@ kernel_restart_handler: reboot # noqa var-naming[no-role-prefix]
 # optionally skip backing up the config file. Can cause issues on some
 # filesystems due to filenames containing illegal characters
 backup_grub_config_file: true # noqa var-naming[no-role-prefix]
+
+grubcmdline_do_reboot: true

--- a/roles/grubcmdline/tasks/main.yml
+++ b/roles/grubcmdline/tasks/main.yml
@@ -10,7 +10,7 @@
     old_cmdline: "{{ result.stdout.split() | select('search', kernel_cmdline_regex) | sort | list }}"
 
 - name: Abort grub cmdline configuration because reboot is disabled
-  fail:
+  ansible.builtin.fail:
     msg: >
       grub cmdline changes requires a reboot, but grubcmdline_do_reboot is
       false. Please run again with grubcmdline_do_reboot set to true to reboot.

--- a/roles/grubcmdline/tasks/main.yml
+++ b/roles/grubcmdline/tasks/main.yml
@@ -9,6 +9,15 @@
   ansible.builtin.set_fact:
     old_cmdline: "{{ result.stdout.split() | select('search', kernel_cmdline_regex) | sort | list }}"
 
+- name: Abort grub cmdline configuration because reboot is disabled
+  fail:
+    msg: >
+      grub cmdline changes requires a reboot, but grubcmdline_do_reboot is
+      false. Please run again with grubcmdline_do_reboot set to true to reboot.
+  when:
+    - old_cmdline != kernel_cmdline | select() | sort | list
+    - not grubcmdline_do_reboot | bool
+
 - name: Notify reboot handler
   ansible.builtin.debug:
     msg: Old command line was {{ result.stdout }}

--- a/roles/iommu/defaults/main.yml
+++ b/roles/iommu/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 # This will prevent Linux from touching devices which cannot be passed through
 iommu_pt: true
+
+iommu_do_reboot: true

--- a/roles/iommu/tasks/main.yml
+++ b/roles/iommu/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_role:
     name: stackhpc.linux.grubcmdline
   vars:
+    grubcmdline_do_reboot: "{{ iommu_do_reboot }}"
     kernel_cmdline: # noqa: var-naming[no-role-prefix]
       - intel_iommu=on
     kernel_cmdline_remove: # noqa: var-naming[no-role-prefix]
@@ -13,6 +14,7 @@
   ansible.builtin.include_role:
     name: stackhpc.linux.grubcmdline
   vars:
+    grubcmdline_do_reboot: "{{ iommu_do_reboot }}"
     kernel_cmdline: # noqa: var-naming[no-role-prefix]
       - iommu=pt
     kernel_cmdline_remove: # noqa: var-naming[no-role-prefix]

--- a/roles/sriov/defaults/main.yml
+++ b/roles/sriov/defaults/main.yml
@@ -26,6 +26,8 @@ sriov_os_pkgs_deb:
   - linux-headers-generic
   - make
 
+sriov_do_reboot: true
+
 sriov_restart_handler: reboot
 
 sriov_numvfs: 8

--- a/roles/sriov/tasks/config.yml
+++ b/roles/sriov/tasks/config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Abort SR-IOV configuration because reboot is disabled
-  fail:
+  ansible.builtin.fail:
     msg: >
       SR-IOV config changes requires a reboot, but sriov_do_reboot is false.
       Please run again with sriov_do_reboot set to true to reboot.

--- a/roles/sriov/tasks/config.yml
+++ b/roles/sriov/tasks/config.yml
@@ -1,4 +1,12 @@
 ---
+- name: Abort SR-IOV configuration because reboot is disabled
+  fail:
+    msg: >
+      SR-IOV config changes requires a reboot, but sriov_do_reboot is false.
+      Please run again with sriov_do_reboot set to true to reboot.
+  when:
+    - not sriov_do_reboot | bool
+
 - name: Persist sriov_numvfs with udev rule
   ansible.builtin.blockinfile:
     path: "{{ sriov_udev_rule_path }}"

--- a/roles/sriov/tasks/config.yml
+++ b/roles/sriov/tasks/config.yml
@@ -2,7 +2,7 @@
 - name: Abort SR-IOV configuration because reboot is disabled
   ansible.builtin.fail:
     msg: >
-      SR-IOV config changes requires a reboot, but sriov_do_reboot is false.
+      SR-IOV config changes require a reboot, but sriov_do_reboot is false.
       Please run again with sriov_do_reboot set to true to reboot.
   when:
     - not sriov_do_reboot | bool

--- a/roles/sriov/tasks/mlxconfig.yml
+++ b/roles/sriov/tasks/mlxconfig.yml
@@ -56,6 +56,19 @@
   become: true
   changed_when: false
 
+- name: Abort SR-IOV configuration because reboot is disabled
+  fail:
+    msg: >
+      SR-IOV config changes requires a reboot, but sriov_do_reboot is false.
+      Please run again with sriov_do_reboot set to true to reboot.
+  vars:
+    sriov_enabled: "{{ mlxconfig_result.stdout | regex_search('^.*SRIOV_EN.*True.*$', multiline=True) }}"
+    regex: ^.*NUM_OF_VFS.*?{{ sriov_numvfs }}.*$
+    num_of_vfs: "{{ mlxconfig_result.stdout | regex_search(regex, multiline=True) }}"
+  when:
+    - (not sriov_enabled) or (not num_of_vfs)
+    - not sriov_do_reboot | bool
+
 - name: Enable SR-IOV with mlxconfig
   ansible.builtin.command: mlxconfig -y -d {{ pci_addr }} set SRIOV_EN=1
   become: true

--- a/roles/sriov/tasks/mlxconfig.yml
+++ b/roles/sriov/tasks/mlxconfig.yml
@@ -59,7 +59,7 @@
 - name: Abort SR-IOV configuration because reboot is disabled
   ansible.builtin.fail:
     msg: >
-      SR-IOV config changes requires a reboot, but sriov_do_reboot is false.
+      SR-IOV config changes require a reboot, but sriov_do_reboot is false.
       Please run again with sriov_do_reboot set to true to reboot.
   vars:
     sriov_enabled: "{{ mlxconfig_result.stdout | regex_search('^.*SRIOV_EN.*True.*$', multiline=True) }}"

--- a/roles/sriov/tasks/mlxconfig.yml
+++ b/roles/sriov/tasks/mlxconfig.yml
@@ -57,7 +57,7 @@
   changed_when: false
 
 - name: Abort SR-IOV configuration because reboot is disabled
-  fail:
+  ansible.builtin.fail:
     msg: >
       SR-IOV config changes requires a reboot, but sriov_do_reboot is false.
       Please run again with sriov_do_reboot set to true to reboot.

--- a/roles/vgpu/tasks/install.yml
+++ b/roles/vgpu/tasks/install.yml
@@ -24,6 +24,14 @@
     ansible_become: true
   when: vgpu_nvidia_driver_install_enabled | bool
   block:
+    - name: Abort VGPU configuration because reboot is disabled
+      fail:
+        msg: >
+          VGPU config changes requires a reboot, but vgpu_do_reboot is false.
+          Please run again with vgpu_do_reboot set to true to reboot.
+      when:
+        - not vgpu_do_reboot | bool
+
     - name: Ensure target directory exists
       ansible.builtin.file:
         state: directory

--- a/roles/vgpu/tasks/install.yml
+++ b/roles/vgpu/tasks/install.yml
@@ -25,7 +25,7 @@
   when: vgpu_nvidia_driver_install_enabled | bool
   block:
     - name: Abort VGPU configuration because reboot is disabled
-      fail:
+      ansible.builtin.fail:
         msg: >
           VGPU config changes requires a reboot, but vgpu_do_reboot is false.
           Please run again with vgpu_do_reboot set to true to reboot.

--- a/roles/vgpu/tasks/install.yml
+++ b/roles/vgpu/tasks/install.yml
@@ -27,7 +27,7 @@
     - name: Abort VGPU configuration because reboot is disabled
       ansible.builtin.fail:
         msg: >
-          VGPU config changes requires a reboot, but vgpu_do_reboot is false.
+          VGPU config changes require a reboot, but vgpu_do_reboot is false.
           Please run again with vgpu_do_reboot set to true to reboot.
       when:
         - not vgpu_do_reboot | bool


### PR DESCRIPTION
Adds equivalent variables to vgpu_do_reboot to the other roles, and adds a task to fail if the user has not explicitly allowed the reboot.

All reboots default to true to avoid breaking existing behaviour.